### PR TITLE
fix(oxlint): remove react compiler nursery rule

### DIFF
--- a/.oxlintrc.react.json
+++ b/.oxlintrc.react.json
@@ -139,8 +139,6 @@
     // - react/hook-use-state
     // - react/jsx-no-leaked-render
 
-    "react/react-compiler": "error",
-
     // custom jsx-a11y rules
     "jsx-a11y/alt-text": [
       "error",


### PR DESCRIPTION
These are now part of the react plugin correctness/suspicious categories

https://oxc.rs/blog/2026-08-18-react-compiler-support.html